### PR TITLE
feat(gatsby): Supports linting Typescript

### DIFF
--- a/packages/gatsby/src/utils/webpack-utils.js
+++ b/packages/gatsby/src/utils/webpack-utils.js
@@ -392,7 +392,7 @@ module.exports = async ({
     let eslint = schema => {
       return {
         enforce: `pre`,
-        test: /\.jsx?$/,
+        test: /\.(jsx?|tsx?)$/,
         exclude: vendorRegex,
         use: [loaders.eslint(schema)],
       }


### PR DESCRIPTION
## Description

Splitted from https://github.com/gatsbyjs/gatsby/pull/16168#issuecomment-515952470

`eslint-config-react-app` has supported linting Typescript since version [3.0.0](https://github.com/facebook/create-react-app/releases/tag/v3.0.0) (facebook/create-react-app#6513).

It would be great if Gatsby also supports this.

## Related Issues

#15976
#16168